### PR TITLE
Update README.md to specify import statement needed in build.gradle.kts

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ tasks {
     }
 }
 ```
+You may need to add an `import org.jetbrains.dokka.gradle.DokkaTask` to the top of `build.gradle.kts` in this case.
 
 [Output formats](#output_formats)
 


### PR DESCRIPTION
Without this, you get errors when Gradle tries to compile `build.gradle.kts`. The fully-qualified name isn't obvious, so adding this information will save at least an Internet search for `DokkaTask` to find where it's defined.